### PR TITLE
Update to use Stimulus 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "babel-loader": "^8.1.0",
     "chokidar": "^3.4.1",
     "express": "^4.17.1",
-    "@hotwired/stimulus": "^3.0.0",
+    "@hotwired/stimulus": "^3.2.0",
     "@hotwired/stimulus-webpack-helpers": "^1.0.0",
     "webpack": "^4.43.0",
     "webpack-dev-middleware": "^3.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -792,10 +792,10 @@
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus-webpack-helpers/-/stimulus-webpack-helpers-1.0.0.tgz#6bd7906a4a2b6e1cd8732203b60264f987bd1084"
   integrity sha512-6oKDmJDSsV+zdlHnF485nneuekY/Zbl669wei4HIiwxUWHhVSU1XIVji4aj+Ws9AXghjTYBS8H5ralB97BVMDw==
 
-"@hotwired/stimulus@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.0.0.tgz#45171e61417af60f0e546665c52fae5b67295cee"
-  integrity sha512-UFIuuf7GjKJoIYromuTmqfzT8gZ8eu5zIB5m2QoEsopymGeN7rfDSTRPyRfwHIqP0x+0vWo4O1LFozw+/sWXxg==
+"@hotwired/stimulus@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.0.tgz#257272f1348b1f7beb1a8510be88b80aec6c4c5b"
+  integrity sha512-uAIIdg049qId0lBhyjuMBfcC5uV8JwbhNLoxEyi9vxM3MW6h+mM97G9rNT4ZZMiqnKK9XUHp9SQUrd9rSLEmpQ==
 
 "@types/json-schema@^7.0.4":
   version "7.0.5"


### PR DESCRIPTION
I lost some time trying to use outlets only to realize that Stimulus wasn’t up to date in this starter 😉 .

This PR only updates `@hotwired/stimulus` dependency version from `3.0.0` to `3.2.0` (latest at this time).